### PR TITLE
cmd: add AppendCleanupFunc for GetObjectReader

### DIFF
--- a/cmd/object-api-utils-storj.go
+++ b/cmd/object-api-utils-storj.go
@@ -1,0 +1,8 @@
+package cmd
+
+// AppendCleanupFunc adds fn which will be called in Close after
+// all internal cleanup functions have been called.
+func (reader *GetObjectReader) AppendCleanupFunc(fn func()) {
+	// cleanUpFns are called in reverse order.
+	reader.cleanUpFns = append([]func(){fn}, reader.cleanUpFns...)
+}


### PR DESCRIPTION
In gateway-mt we need to close the associated project after using the download. There's no easy way of achieving this due to the many layers.

Attaching the project.Close to the GetObjectReader, makes things much easier.